### PR TITLE
Add slash escape

### DIFF
--- a/json.c
+++ b/json.c
@@ -108,6 +108,9 @@ static const char *decode_string(const char **p, Janet *out) {
                 case '\\':
                     b = '\\';
                     break;
+                case '/':
+                    b = '/';
+                    break;
                 case 'u':
                     {
                         /* Get codepoint and check for surrogate pair */


### PR DESCRIPTION
\/ seems to be a valid escape sequence in JSON. So I thought it would be good idea to add it also to JSON parser.